### PR TITLE
Fix s2i build process

### DIFF
--- a/docker/manage
+++ b/docker/manage
@@ -137,6 +137,7 @@ build-api() {
 
   echoGreen "\n\nBuilding api ...\n"
   ${S2I_EXE} build \
+    --copy \
     -s 'file://../.s2i/bin' \
     '../' \
     "${BASE_IMAGE}" \


### PR DESCRIPTION
- Add `--copy` to s2i builds so they build off the working copy changes rather that the latest commit.

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>