### PR TITLE
Liquibase migration tweaks.

### DIFF
--- a/database/liquibase/shersched.db.changelog.env-schemas_roles_extensions.xml
+++ b/database/liquibase/shersched.db.changelog.env-schemas_roles_extensions.xml
@@ -1,15 +1,15 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
-<databaseChangeLog 
-    xmlns="http://www.liquibase.org/xml/ns/dbchangelog" 
-    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" 
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
-    
-    
+
+
     <changeSet author="Carol Geisler" id="tag0">
     	<tagDatabase tag="database_env_start"/>
     </changeSet>
-    
+
     <changeSet author="Colter McQuay" id="db_env_01_schema">
         <sql>
             CREATE SCHEMA IF NOT EXISTS "${POSTGRES_SCHEMA}";
@@ -21,7 +21,12 @@
         </rollback>
     </changeSet>
 
-    <changeSet author="Michael Gabelmann" id="db_env_02_app_user">
+    <changeSet author="Lucas Lopatka" id="db_env_02_app_user">
+        <sql>
+            REASSIGN OWNED BY ${POSTGRES_APP_USER} TO postgres;
+            DROP OWNED BY ${POSTGRES_APP_USER};
+            DROP USER ${POSTGRES_APP_USER};
+        </sql>
         <sql>
             CREATE USER ${POSTGRES_APP_USER} WITH PASSWORD '${POSTGRES_APP_PASS}';
         </sql>
@@ -32,7 +37,7 @@
         </rollback>
     </changeSet>
 
-    
+
     <changeSet author="Michael Gabelmann" id="db_env_03_schema_grant">
         <sql>
             GRANT USAGE ON SCHEMA "${POSTGRES_SCHEMA}" TO "${POSTGRES_APP_USER}";
@@ -43,8 +48,8 @@
             </sql>
         </rollback>
     </changeSet>
-    
-    
+
+
     <changeSet author="Carol Geisler" id="db_env_04_extension_schema">
         <sql>
             CREATE SCHEMA IF NOT EXISTS "${POSTGRES_EXT_SCHEMA}";
@@ -57,16 +62,16 @@
         	</sql>
         </rollback>
     </changeSet>
-    
+
     <changeSet author="Michael Gabelmann" id="db_env_05_uuid_extension">
         <sql>
             CREATE EXTENSION IF NOT EXISTS "uuid-ossp" SCHEMA ${POSTGRES_EXT_SCHEMA};
         </sql>
         <rollback/><!-- no rollback as this is potentially shared -->
     </changeSet>
-		
+
     <changeSet author="Carol Geisler" id="tag1">
     	<tagDatabase tag="database_env_end"/>
     </changeSet>
-    
+
 </databaseChangeLog>

--- a/database/liquibase/structure/v2-authorization/shersched.db.changelog.authorization.table-auth_user.xml
+++ b/database/liquibase/structure/v2-authorization/shersched.db.changelog.authorization.table-auth_user.xml
@@ -9,10 +9,10 @@
             <!-- Siteminder integration -->
             <column name="user_auth_id" type="varchar(100)">
                 <!-- Used for IDIR -->
-                <constraints nullable="false"/>
+                <constraints nullable="true"/>
             </column>
             <column name="siteminder_id" type="varchar(100)">
-                <constraints nullable="false"/>
+                <constraints nullable="true"/>
                 <!-- Can be used to map Super User accounts -->
             </column>
             <!-- Siteminder account display name -->


### PR DESCRIPTION
Reassign and drop POSTGRES_APP_USER permissions and user before creating the user in migrations. Make auth_user.user_auth_id (IDIR) and auth_user.siteminder_id to fix sheriff record generation from users.

<!-- BUG FIX-->
## Fixes [Issue](#)

<!-- OR FEATURE -->
## Adds [Feature](#)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests are all passing
- [ ] Run `yarn rebuild` to regenerate/rebuild the API and Client 

> #### If there are resulting changes within `/dist/`
> - [ ] Bump the version in `package.json` according to [Semver](https://semver.org/) 
>  - [ ] Commit `package.json` along with all changes within `/dist/` with description of API Updates

- [ ] Update the Changelog!



